### PR TITLE
[feat/3]: Nav 바 UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@types/react-dom": "^18.2.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.9.0",
         "react-redux": "^8.0.7",
         "react-router-dom": "^6.11.2",
         "react-scripts": "5.0.1",
@@ -24,6 +25,9 @@
         "styled-components": "^5.3.11",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@types/styled-components": "^5.1.26"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4219,6 +4223,17 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
+    },
+    "node_modules/@types/styled-components": {
+      "version": "5.1.26",
+      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.26.tgz",
+      "integrity": "sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==",
+      "dev": true,
+      "dependencies": {
+        "@types/hoist-non-react-statics": "*",
+        "@types/react": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.6",
@@ -14372,6 +14387,14 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-icons": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.9.0.tgz",
+      "integrity": "sha512-ijUnFr//ycebOqujtqtV9PFS7JjhWg0QU6ykURVHuL4cbofvRCf3f6GMn9+fBktEFQOIVZnuAYLZdiyadRQRFg==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "^18.2.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.9.0",
     "react-redux": "^8.0.7",
     "react-router-dom": "^6.11.2",
     "react-scripts": "5.0.1",
@@ -43,5 +44,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@types/styled-components": "^5.1.26"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,13 +6,15 @@ import EventDetailPage from './pages/EventDetailPage';
 
 function App() {
   return (
-    <BrowserRouter basename={process.env.BASE_URL}>
-      <Routes>
-        <Route path='/calendar' element={<Main />} />
-        <Route path='/events/new' element={<EventPostPage />} />
-        <Route path='/events/:eventId' element={<EventDetailPage />} />
-      </Routes>
-    </BrowserRouter>
+    <div className='App'>
+      <BrowserRouter basename={process.env.BASE_URL}>
+        <Routes>
+          <Route path='/calendar' element={<Main />} />
+          <Route path='/events/new' element={<EventPostPage />} />
+          <Route path='/events/:eventId' element={<EventDetailPage />} />
+        </Routes>
+      </BrowserRouter>
+    </div>
   );
 }
 

--- a/src/components/base/DateFormatComboBox.tsx
+++ b/src/components/base/DateFormatComboBox.tsx
@@ -1,0 +1,43 @@
+import { RxTriangleDown } from 'react-icons/rx';
+import styled from 'styled-components';
+import useDateFormat from '../../hooks/useDateFormat';
+import ComboBox from '../common/ComboBox';
+
+const DATE_FORMAT_OPTIONS = [
+  { name: '일', shortCut: 'D', id: 1 },
+  { name: '주', shortCut: 'W', id: 2 },
+  { name: '월', shortCut: 'M', id: 3 },
+];
+
+const DateFormatComboBox = () => {
+  const [openDropdown, isOpenedDropdown] = useDateFormat();
+
+  return (
+    <ComboBox
+      fieldText={
+        <>
+          <span>월</span>
+          <DropdownIcon />
+        </>
+      }
+      onClick={openDropdown}
+      isVisible={isOpenedDropdown}
+      options={
+        <>
+          {Object.values(DATE_FORMAT_OPTIONS).map((v) => (
+            <div key={v.id}>
+              <span>{v.name}</span>
+              <span>{v.shortCut}</span>
+            </div>
+          ))}
+        </>
+      }
+    />
+  );
+};
+
+export default DateFormatComboBox;
+
+const DropdownIcon = styled(RxTriangleDown)`
+  margin-left: 5px;
+`;

--- a/src/components/base/Header.tsx
+++ b/src/components/base/Header.tsx
@@ -1,0 +1,67 @@
+import styled from 'styled-components';
+
+import { colors } from '../../lib/styles/colors';
+import AdjacentArrows from '../common/AdjacentArrows';
+import TodayButton from '../common/TodayButton';
+import DateFormatComboBox from './DateFormatComboBox';
+import HeaderDate from './HeaderDate';
+import HeaderLogo from './HeaderLogo';
+
+const Header = () => {
+  return (
+    <Container>
+      <Inner>
+        <Left>
+          <HeaderLogo />
+        </Left>
+        <Center>
+          <TodayButton />
+          <AdjacentArrows />
+          <HeaderDate />
+        </Center>
+        <Right>
+          <DateFormatComboBox />
+        </Right>
+      </Inner>
+    </Container>
+  );
+};
+
+export default Header;
+
+const Container = styled.div`
+  padding: 5px 3%;
+  border-bottom: 1px solid ${colors.gray100};
+`;
+
+const Inner = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: 48px;
+
+  & > * {
+    width: 33%;
+  }
+`;
+
+const Left = styled.div``;
+
+const Center = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding: 0 auto;
+  text-align: center;
+  max-width: 400px;
+
+  & > * {
+    margin: 0 auto;
+  }
+`;
+
+const Right = styled.div`
+  display: flex;
+  justify-content: end;
+`;

--- a/src/components/base/HeaderDate.tsx
+++ b/src/components/base/HeaderDate.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+import { colors } from '../../lib/styles/colors';
+
+const HeaderDate = () => {
+  // TODO: add state of Today's date (input field & date picker)
+  return <Container>2023년 6월</Container>;
+};
+
+export default HeaderDate;
+
+const Container = styled.span`
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  border: none;
+  color: ${colors.gray800};
+  background-color: transparent;
+  font-size: calc(0.8rem + 0.8vw);
+  line-height: 28px;
+`;

--- a/src/components/base/HeaderLogo.tsx
+++ b/src/components/base/HeaderLogo.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+import { colors } from '../../lib/styles/colors';
+
+const HeaderLogo = () => {
+  // TODO: add state of today's date
+  return <Container aria-label='구글 캘린더 로고'>7</Container>;
+};
+
+export default HeaderLogo;
+
+const Container = styled.div.attrs((props) => ({
+  'aria-label': props['aria-label'],
+}))`
+  text-align: center;
+  width: 20px;
+  color: ${colors.mainBlue};
+  border-left: 5px solid ${colors.mainBlue};
+  border-top: 5px solid ${colors.mainBlue};
+  border-right: 5px solid ${colors.mainYellow};
+  border-bottom: 5px solid ${colors.mainGreen};
+  border-radius: 3px;
+`;

--- a/src/components/common/AdjacentArrows.tsx
+++ b/src/components/common/AdjacentArrows.tsx
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+
+import { RxCaretLeft, RxCaretRight } from 'react-icons/rx';
+import { colors } from '../../lib/styles/colors';
+
+const AdjacentArrows = () => {
+  return (
+    <Container>
+      <Button aria-label='이전 달로 이동하는 버튼'>
+        <RxCaretLeft size={25} />
+      </Button>
+      <Button aria-label='다음 달로 이동하는 버튼'>
+        <RxCaretRight size={25} />
+      </Button>
+    </Container>
+  );
+};
+
+export default AdjacentArrows;
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const Button = styled.button.attrs((props) => ({
+  'aria-label': props['aria-label'],
+}))`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0;
+  background-color: transparent;
+  border: none;
+  width: 30px;
+  height: 30px;
+  cursor: pointer;
+  border-radius: 15px;
+  transition: background-color 0.1s ease-in-out;
+
+  &:hover {
+    background-color: ${colors.gray50};
+  }
+
+  & > * {
+    margin: 0 5px;
+    font-size: 24px;
+    color: ${colors.gray200};
+  }
+`;

--- a/src/components/common/ButtonField.tsx
+++ b/src/components/common/ButtonField.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import styled, { css } from 'styled-components';
+
+import { colors } from '../../lib/styles/colors';
+import { MouseEventType } from '../../lib/types';
+
+type ButtonFieldType = {
+  children: React.ReactNode;
+  onClick?: MouseEventType<HTMLButtonElement>;
+  variants: 'primary' | 'secondary';
+};
+
+const ButtonField = ({
+  children,
+  variants = 'primary',
+  onClick,
+}: ButtonFieldType) => {
+  return (
+    <ButtonFieldContainer onClick={onClick} variants={variants}>
+      {children}
+    </ButtonFieldContainer>
+  );
+};
+
+export default ButtonField;
+
+const variantStyles = {
+  primary: css`
+    background: white;
+  `,
+  secondary: css`
+    background: ${colors.graySecondary};
+  `,
+};
+
+const ButtonFieldContainer = styled.button<ButtonFieldType>`
+  ${(props) => variantStyles[props.variants]}
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+  padding: 8px 2vw;
+  border: 1px solid ${colors.gray100};
+  border-radius: 4px;
+  color: ${colors.gray800};
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.1s ease-in-out;
+
+  &:hover {
+    background-color: ${colors.gray50};
+  }
+
+  &:active {
+    background-color: ${colors.gray100};
+  }
+`;

--- a/src/components/common/ComboBox.tsx
+++ b/src/components/common/ComboBox.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { MouseEventType } from '../../lib/types';
+import ButtonField from './ButtonField';
+import Dropdown from './Dropdown';
+
+type ComboBoxType = {
+  fieldText: React.ReactNode;
+  options: React.ReactNode;
+  onClick: MouseEventType<HTMLButtonElement>;
+  isVisible: boolean;
+};
+
+const ComboBox = ({ fieldText, options, onClick, isVisible }: ComboBoxType) => {
+  return (
+    <Container>
+      {/* TODO: split this ComboBoxInput into another component */}
+      {/* TODO: add state of date format */}
+      <ComboBoxInput
+        variants='primary'
+        children={fieldText}
+        onClick={onClick}
+      />
+      {isVisible && <ComboBoxOptions options={options} />}
+    </Container>
+  );
+};
+
+export default ComboBox;
+
+const Container = styled.div`
+  position: relative;
+  /* width: 100%; */
+`;
+
+const ComboBoxInput = styled(ButtonField)``;
+
+const ComboBoxOptions = styled(Dropdown)``;

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { colors } from '../../lib/styles/colors';
+
+type DropdownType = {
+  options: React.ReactNode;
+};
+
+const Dropdown = ({ options }: DropdownType) => {
+  return <Container>{options}</Container>;
+};
+
+export default Dropdown;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: absolute;
+  top: 40px;
+  right: 0;
+  min-width: 100px;
+  padding: 8px 0;
+  border: 1px solid ${colors.gray100};
+  border-radius: 4px;
+  background-color: #fff;
+  box-shadow: 0 3px 5px -1px rgba(0, 0, 0, 0.2),
+    0 6px 10px 0 rgba(0, 0, 0, 0.14),
+    //
+    0 1px 18px 0 rgba(0, 0, 0, 0.12);
+
+  & > div {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 10px;
+    height: 30px;
+    font-size: 0.8rem;
+    color: ${colors.gray800};
+    cursor: pointer;
+  }
+
+  & > div:hover {
+    background-color: ${colors.gray50};
+  }
+`;

--- a/src/components/common/TodayButton.tsx
+++ b/src/components/common/TodayButton.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ButtonField from './ButtonField';
+import styled from 'styled-components';
+
+const TodayButton = () => <Container variants='primary'>오늘</Container>;
+
+export default TodayButton;
+
+const Container = styled(ButtonField)``;

--- a/src/components/home/HomeLayout.tsx
+++ b/src/components/home/HomeLayout.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styled from 'styled-components';
+
+type HomeLayoutProps = {
+  children: React.ReactNode;
+};
+
+const HomeLayout = ({ children }: HomeLayoutProps) => {
+  return <Container>{children}</Container>;
+};
+
+export default HomeLayout;
+
+const Container = styled.div``;

--- a/src/components/main/MainTemplate.tsx
+++ b/src/components/main/MainTemplate.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styled from 'styled-components';
+
+type MainTemplateType = {
+  children: React.ReactNode;
+};
+
+const MainTemplate = ({ children }: MainTemplateType) => {
+  return <Container>{children}</Container>;
+};
+
+export default MainTemplate;
+
+const Container = styled.div``;

--- a/src/hooks/useDateFormat.ts
+++ b/src/hooks/useDateFormat.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+
+type OpenDropdownType = () => void;
+
+const useDateFormat = (): [OpenDropdownType, boolean] => {
+  const [isOpenedDropdown, setIsOpenedDropdown] = useState(false);
+
+  const openDropdown: OpenDropdownType = () => {
+    setIsOpenedDropdown((prev) => !prev);
+  };
+
+  return [openDropdown, isOpenedDropdown];
+};
+
+export default useDateFormat;

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,13 @@
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap');
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+  font-family: 'Lato', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  font-size: 16px;
 }
 
 code {

--- a/src/lib/styles/colors.ts
+++ b/src/lib/styles/colors.ts
@@ -1,0 +1,10 @@
+export const colors = {
+  graySecondary: '#F1F3F4',
+  gray50: '#F6F6F6',
+  gray100: '#DADCE0',
+  gray200: '#5F6368',
+  gray800: '#3C4043',
+  mainBlue: '#4285F4',
+  mainGreen: '#34A853',
+  mainYellow: '#FBBC05',
+};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,3 @@
+import { EventHandler, MouseEvent } from 'react';
+
+export type MouseEventType<T = Element> = EventHandler<MouseEvent<T>>;

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,7 +1,14 @@
-import React from 'react';
+import Header from '../components/base/Header';
+import HomeLayout from '../components/home/HomeLayout';
+import MainTemplate from '../components/main/MainTemplate';
 
 const Main = () => {
-  return <div>Main</div>;
+  return (
+    <MainTemplate>
+      <Header />
+      <HomeLayout children={<>Main</>} />
+    </MainTemplate>
+  );
 };
 
 export default Main;


### PR DESCRIPTION
## 구현 내용
![Nav bar 구현 데스크탑](https://github.com/04ian80/google-calendar/assets/97023321/a9c91454-d345-4b11-b683-0441991362cc)

- react-icons 및 styled-components type 추가 설치.
- 구글 폰트의 lato import. 기존 서비스의 폰트는 'Google Sans'이지만 google font에는 해당 폰트가 존재하지 않음.
- NavBar(Header) 구현.
- 자주 쓰는 색상 속성 **palette로 재사용** (colors.ts)
- MouseEvent **타입 제네릭 변수 전달로 재사용성 up**
- **headless ui** 라는 것을 이번주에 배워서 최대한 headless ui로 구현해보았음.
  - 오늘로 이동하는 버튼이나 월,주,일을 선택하는 버튼은 스타일이 똑같기 때문에 ButtonField라는 스타일을 공유하는 컴포넌트를 만들어 재사용할 수 있도록 하였고, 각자 TodayButton과 ComboBox에서 쓰임.
  - ButtonField는 추후에 이벤트 생성 페이지에서도 다른 스타일로 많이 쓰이기 때문에 **primary, secondary로 variants를 만들어 사용 가능하도록 제작**.
  - ComboBox는 ComboInput과 ComboOptions로 나누어져있고 각각 ButtonField 컴포넌트와 Dropdown 컴포넌트를 사용함으로써 **ComboBox를 재사용 할 수 있게함**. (여기서 DropDown도 재사용할 수 있음.)
  - 이 ComboBox를 DateFormatComboBox라는 월,주,일을 선택할 수 있는 ComboBox를 만들어 사용. (Header에서 사용)
  - DateFormatComboBox에서 필요한 기능은 해당 코드 내에서가 아닌 useDateFormat이라는 **커스텀 훅**에서 가져와서 사용.
- 스크린리더에게 부가 설명이 필요한 요소에 대해 **aria-label 적용**.
- 반응형 고려하여 구현
![Nav bar 구현 모바일](https://github.com/04ian80/google-calendar/assets/97023321/8b6aeb37-d0a6-4655-9287-473ada4a049f)



## 체크리스트 (기능 구현x UI only)
- [x] 오늘 날짜로 이동하는 버튼
- [x] 단위별로 (월, 주, 일) 이동하는 버튼
- [x] 현재 위치해 있는 날짜 표시
- [x] 월, 주, 일 선택할 수 있는 드롭다운 버튼